### PR TITLE
add stat for blocks sieved

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/common/init/ExNihiloInitialization.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/init/ExNihiloInitialization.java
@@ -125,6 +125,7 @@ public class ExNihiloInitialization {
         BarrelModeRegistry.initialize();
         PacketHandler.registerMessages();
         registerVanillaCompost();
+        ExNihiloStats.register();
     }
 
     private static void registerVanillaCompost() {

--- a/src/main/java/novamachina/exnihilosequentia/common/init/ExNihiloStats.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/init/ExNihiloStats.java
@@ -1,0 +1,16 @@
+package novamachina.exnihilosequentia.common.init;
+
+import net.minecraft.stats.IStatFormatter;
+import net.minecraft.stats.Stats;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
+import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
+
+public class ExNihiloStats {
+    public static final ResourceLocation SIEVED = new ResourceLocation(ExNihiloConstants.ModIds.EX_NIHILO_SEQUENTIA, "sieved");
+
+    public static void register() {
+        Registry.register(Registry.CUSTOM_STAT, SIEVED, SIEVED);
+        Stats.CUSTOM.get(SIEVED, IStatFormatter.DEFAULT);
+    }
+}

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/SieveTile.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/SieveTile.java
@@ -11,6 +11,7 @@ import net.minecraftforge.common.util.FakePlayer;
 import novamachina.exnihilosequentia.api.ExNihiloRegistries;
 import novamachina.exnihilosequentia.api.crafting.sieve.SieveRecipe;
 import novamachina.exnihilosequentia.common.block.BlockSieve;
+import novamachina.exnihilosequentia.common.init.ExNihiloStats;
 import novamachina.exnihilosequentia.common.init.ExNihiloTiles;
 import novamachina.exnihilosequentia.common.item.mesh.EnumMesh;
 import novamachina.exnihilosequentia.common.item.mesh.MeshItem;
@@ -183,6 +184,9 @@ public class SieveTile extends TileEntity {
                             .getZ() + 0.5F, entry.getDrop()));
                     }
                 })));
+                if (player != null) {
+                    player.awardStat(ExNihiloStats.SIEVED);
+                }
                 resetSieve();
             }
         }

--- a/src/main/resources/assets/exnihilosequentia/lang/en_us.json
+++ b/src/main/resources/assets/exnihilosequentia/lang/en_us.json
@@ -133,6 +133,8 @@
   
   "item.exnihilosequentia.item_stick_stone": "Stone Stick",
 
+  "stat.exnihilosequentia.sieved": "Blocks Sieved",
+
   "tooltip.doll.blaze": "Add to a barrel of lava to spawn a Blaze",
   "tooltip.doll.enderman": "Add to a barrel of witchwater to spawn an Enderman",
   "tooltip.doll.shulker": "Add to a barrel of witchwater to spawn a Shulker",


### PR DESCRIPTION
It could be really cool to know, how many blocks you sieved manually. 
Another reason why I made this, is a project called "Bingo". I wanted to add a stat task for blocks sieved but there was no stat for this. This will be changed with this.