### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/novamachina/9b4371f9-393b-4d7d-8cb9-1f6c864e3511/79b0a5ab-a029-4b0f-9360-17c79f690771/_apis/work/boardbadge/c246212b-c074-4d92-a143-77fdc39d931c)](https://dev.azure.com/novamachina/9b4371f9-393b-4d7d-8cb9-1f6c864e3511/_boards/board/t/79b0a5ab-a029-4b0f-9360-17c79f690771/Microsoft.RequirementCategory)
 <p align="center">
     <a href="https://www.curseforge.com/minecraft/mc-mods/ex-nihilo-sequentia"><img src="http://cf.way2muchnoise.eu/full_400012_downloads.svg" /></a>
     <a href="https://www.curseforge.com/minecraft/mc-mods/ex-nihilo-sequentia"><img src="http://cf.way2muchnoise.eu/versions/400012.svg" /></a>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/novamachina/9b4371f9-393b-4d7d-8cb9-1f6c864e3511/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.