### PR TITLE
Fix #265: Add campfires as a heat source

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/api/crafting/heat/HeatRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/api/crafting/heat/HeatRecipe.java
@@ -1,6 +1,8 @@
 package novamachina.exnihilosequentia.api.crafting.heat;
 
+import net.minecraft.advancements.criterion.StatePropertiesPredicate;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.ResourceLocation;
@@ -14,11 +16,20 @@ public class HeatRecipe extends SerializableRecipe {
     private static RegistryObject<RecipeSerializer<HeatRecipe>> serializer;
     private int amount;
     private Block input;
+    private StatePropertiesPredicate properties;
 
     public HeatRecipe(ResourceLocation id, Block input, int amount) {
         super(null, RECIPE_TYPE, id);
         this.input = input;
         this.amount = amount;
+        this.properties = null;
+    }
+
+    public HeatRecipe(ResourceLocation id, Block input, int amount, StatePropertiesPredicate properties) {
+        super(null, RECIPE_TYPE, id);
+        this.input = input;
+        this.amount = amount;
+        this.properties = properties;
     }
 
     public static RegistryObject<RecipeSerializer<HeatRecipe>> getStaticSerializer() {
@@ -41,8 +52,21 @@ public class HeatRecipe extends SerializableRecipe {
         return input;
     }
 
+    public StatePropertiesPredicate getProperties() {
+        return this.properties;
+    }
+
     public void setInput(Block input) {
         this.input = input;
+    }
+
+    public void setProperties(StatePropertiesPredicate properties) {
+        this.properties = properties;
+    }
+
+    public boolean isMatch(BlockState state) {
+        return state.getBlock().getRegistryName().equals(this.input.getRegistryName())
+                && (this.properties == null || this.properties.matches(state));
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/api/crafting/heat/HeatRecipeBuilder.java
+++ b/src/main/java/novamachina/exnihilosequentia/api/crafting/heat/HeatRecipeBuilder.java
@@ -1,5 +1,6 @@
 package novamachina.exnihilosequentia.api.crafting.heat;
 
+import net.minecraft.advancements.criterion.StatePropertiesPredicate;
 import net.minecraft.block.Block;
 import net.minecraft.item.crafting.Ingredient;
 import novamachina.exnihilosequentia.api.crafting.ExNihiloFinishedRecipe;
@@ -23,5 +24,9 @@ public class HeatRecipeBuilder extends ExNihiloFinishedRecipe<HeatRecipeBuilder>
 
     public HeatRecipeBuilder input(Block block) {
         return this.addBlock(block);
+    }
+
+    public HeatRecipeBuilder properties(StatePropertiesPredicate properties) {
+        return this.addWriter(jsonObj -> jsonObj.add("state", properties.serializeToJson()));
     }
 }

--- a/src/main/java/novamachina/exnihilosequentia/api/datagen/AbstractRecipeGenerator.java
+++ b/src/main/java/novamachina/exnihilosequentia/api/datagen/AbstractRecipeGenerator.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 
 import net.minecraft.advancements.criterion.InventoryChangeTrigger;
 import net.minecraft.advancements.criterion.ItemPredicate;
+import net.minecraft.advancements.criterion.StatePropertiesPredicate;
 import net.minecraft.block.Block;
 import net.minecraft.block.ComposterBlock;
 import net.minecraft.data.CookingRecipeBuilder;
@@ -31,7 +32,6 @@ import novamachina.exnihilosequentia.api.crafting.fluidtransform.FluidTransformR
 import novamachina.exnihilosequentia.api.crafting.hammer.HammerRecipeBuilder;
 import novamachina.exnihilosequentia.api.crafting.heat.HeatRecipeBuilder;
 import novamachina.exnihilosequentia.common.block.BaseBlock;
-import novamachina.exnihilosequentia.common.block.BlockBarrel;
 import novamachina.exnihilosequentia.common.block.BlockSieve;
 import novamachina.exnihilosequentia.common.item.ore.EnumOre;
 import novamachina.exnihilosequentia.common.tileentity.crucible.CrucilbeTypeEnum;
@@ -192,6 +192,10 @@ public abstract class AbstractRecipeGenerator extends RecipeProvider {
 
     protected void createHeatRecipes(Consumer<IFinishedRecipe> consumer, Block block, int amount, String id) {
         HeatRecipeBuilder.builder().input(block).amount(amount).build(consumer, heatLoc(id));
+    }
+
+    protected void createHeatRecipes(Consumer<IFinishedRecipe> consumer, Block block, int amount, StatePropertiesPredicate properties, String id) {
+        HeatRecipeBuilder.builder().input(block).amount(amount).properties(properties).build(consumer, heatLoc(id));
     }
 
     protected void createSmeltingRecipe(Consumer<IFinishedRecipe> consumer, Item input, Item output, float xpSmelt, int durationSmelt, float xpBlast, int durationBlast, String condition, ResourceLocation rl) {

--- a/src/main/java/novamachina/exnihilosequentia/api/registry/IHeatRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/api/registry/IHeatRegistry.java
@@ -1,14 +1,13 @@
 package novamachina.exnihilosequentia.api.registry;
 
 import java.util.List;
-import net.minecraft.util.IItemProvider;
-import net.minecraftforge.registries.ForgeRegistryEntry;
+import net.minecraft.block.BlockState;
 import novamachina.exnihilosequentia.api.crafting.heat.HeatRecipe;
 
 public interface IHeatRegistry {
     void clearRecipes();
 
-    int getHeatAmount(ForgeRegistryEntry<? extends IItemProvider> entry);
+    int getHeatAmount(BlockState entry);
 
     List<HeatRecipe> getRecipeList();
 

--- a/src/main/java/novamachina/exnihilosequentia/common/compat/crafttweaker/builder/ZenHeatRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/compat/crafttweaker/builder/ZenHeatRecipe.java
@@ -1,6 +1,7 @@
 package novamachina.exnihilosequentia.common.compat.crafttweaker.builder;
 
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.impl.predicate.StatePropertiesPredicate;
 import net.minecraft.block.Block;
 import net.minecraft.util.ResourceLocation;
 import novamachina.exnihilosequentia.api.crafting.heat.HeatRecipe;
@@ -34,6 +35,12 @@ public class ZenHeatRecipe {
     @ZenCodeType.Method
     public ZenHeatRecipe setBlock(Block input) {
         internal.setInput(input);
+        return this;
+    }
+
+    @ZenCodeType.Method
+    public ZenHeatRecipe setProperties(StatePropertiesPredicate properties) {
+        internal.setProperties(properties.toVanilla());
         return this;
     }
 }

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/serializer/HeatRecipeSerializer.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/serializer/HeatRecipeSerializer.java
@@ -1,6 +1,8 @@
 package novamachina.exnihilosequentia.common.crafting.serializer;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import net.minecraft.advancements.criterion.StatePropertiesPredicate;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
@@ -16,10 +18,15 @@ public class HeatRecipeSerializer extends RecipeSerializer<HeatRecipe> {
         return new ItemStack(ExNihiloBlocks.CRUCIBLE_FIRED.get());
     }
 
+    private static final JsonParser PARSER = new JsonParser();
+
     @Override
     public HeatRecipe fromNetwork(ResourceLocation recipeId, PacketBuffer buffer) {
         Block input = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(buffer.readUtf()));
         int amount = buffer.readInt();
+        if (buffer.readBoolean()) {
+            return  new HeatRecipe(recipeId, input, amount, StatePropertiesPredicate.fromJson(PARSER.parse(buffer.readUtf())));
+        }
         return new HeatRecipe(recipeId, input, amount);
     }
 
@@ -27,12 +34,22 @@ public class HeatRecipeSerializer extends RecipeSerializer<HeatRecipe> {
     public void toNetwork(PacketBuffer buffer, HeatRecipe recipe) {
         buffer.writeUtf(recipe.getInput().getRegistryName().toString());
         buffer.writeInt(recipe.getAmount());
+        StatePropertiesPredicate properties = recipe.getProperties();
+        if (properties != null) {
+            buffer.writeBoolean(true);
+            buffer.writeUtf(recipe.getProperties().serializeToJson().toString());
+        } else {
+            buffer.writeBoolean(false);
+        }
     }
 
     @Override
     protected HeatRecipe readFromJson(ResourceLocation recipeId, JsonObject json) {
         Block input = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(json.get("block").getAsString()));
         int amount = json.get("amount").getAsInt();
+        if (json.has("state")) {
+            return new HeatRecipe(recipeId, input, amount, StatePropertiesPredicate.fromJson(json.get("state")));
+        }
         return new HeatRecipe(recipeId, input, amount);
     }
 }

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/serializer/HeatRecipeSerializer.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/serializer/HeatRecipeSerializer.java
@@ -37,7 +37,7 @@ public class HeatRecipeSerializer extends RecipeSerializer<HeatRecipe> {
         StatePropertiesPredicate properties = recipe.getProperties();
         if (properties != null) {
             buffer.writeBoolean(true);
-            buffer.writeUtf(recipe.getProperties().serializeToJson().toString());
+            buffer.writeUtf(properties.serializeToJson().toString());
         } else {
             buffer.writeBoolean(false);
         }

--- a/src/main/java/novamachina/exnihilosequentia/common/datagen/ExNihiloRecipeGenerator.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/datagen/ExNihiloRecipeGenerator.java
@@ -360,12 +360,13 @@ public class ExNihiloRecipeGenerator extends AbstractRecipeGenerator {
         createHeatRecipes(consumer, Blocks.SHROOMLIGHT, 2, "shroomlight");
         createHeatRecipes(consumer, Blocks.SOUL_FIRE, 4, "soul_fire");
 
-        // Lightable blocks
-        StatePropertiesPredicate lightable = StatePropertiesPredicate.Builder.properties().hasProperty(BlockStateProperties.LIT, true).build();
-        HeatRecipeBuilder.builder().input(Blocks.CAMPFIRE).amount(4).properties(lightable).build(consumer, heatLoc("campfire"));
-        HeatRecipeBuilder.builder().input(Blocks.SOUL_CAMPFIRE).amount(4).properties(lightable).build(consumer, heatLoc("soul_campfire"));
-        HeatRecipeBuilder.builder().input(Blocks.FURNACE).amount(3).properties(lightable).build(consumer, heatLoc("furnace"));
-        HeatRecipeBuilder.builder().input(Blocks.REDSTONE_TORCH).amount(1).properties(lightable).build(consumer, heatLoc("redstone_torch"));
+        // Lit blocks
+        StatePropertiesPredicate lit = StatePropertiesPredicate.Builder.properties().hasProperty(BlockStateProperties.LIT, true).build();
+        createHeatRecipes(consumer, Blocks.CAMPFIRE, 4, lit, "campfire");
+        createHeatRecipes(consumer, Blocks.SOUL_CAMPFIRE, 4, lit, "soul_campfire");
+        createHeatRecipes(consumer, Blocks.FURNACE, 3, lit, "furnace");
+        createHeatRecipes(consumer, Blocks.REDSTONE_TORCH, 1, lit, "redstone_torch");
+        createHeatRecipes(consumer, Blocks.REDSTONE_WALL_TORCH, 1, lit, "redstone_wall_torch");
     }
 
     private void registerIronOres(Consumer<IFinishedRecipe> consumer, EnumOre ore) {

--- a/src/main/java/novamachina/exnihilosequentia/common/datagen/ExNihiloRecipeGenerator.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/datagen/ExNihiloRecipeGenerator.java
@@ -2,6 +2,7 @@ package novamachina.exnihilosequentia.common.datagen;
 
 import net.minecraft.advancements.criterion.InventoryChangeTrigger;
 import net.minecraft.advancements.criterion.ItemPredicate;
+import net.minecraft.advancements.criterion.StatePropertiesPredicate;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.data.*;
@@ -10,10 +11,12 @@ import net.minecraft.fluid.Fluids;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.Tags;
 import novamachina.exnihilosequentia.api.ExNihiloTags;
+import novamachina.exnihilosequentia.api.crafting.heat.HeatRecipeBuilder;
 import novamachina.exnihilosequentia.api.crafting.sieve.MeshWithChance;
 import novamachina.exnihilosequentia.api.crafting.sieve.SieveRecipeBuilder;
 import novamachina.exnihilosequentia.api.datagen.AbstractRecipeGenerator;
@@ -356,6 +359,13 @@ public class ExNihiloRecipeGenerator extends AbstractRecipeGenerator {
         createHeatRecipes(consumer, Blocks.GLOWSTONE, 2, "glowstone");
         createHeatRecipes(consumer, Blocks.SHROOMLIGHT, 2, "shroomlight");
         createHeatRecipes(consumer, Blocks.SOUL_FIRE, 4, "soul_fire");
+
+        // Lightable blocks
+        StatePropertiesPredicate lightable = StatePropertiesPredicate.Builder.properties().hasProperty(BlockStateProperties.LIT, true).build();
+        HeatRecipeBuilder.builder().input(Blocks.CAMPFIRE).amount(4).properties(lightable).build(consumer, heatLoc("campfire"));
+        HeatRecipeBuilder.builder().input(Blocks.SOUL_CAMPFIRE).amount(4).properties(lightable).build(consumer, heatLoc("soul_campfire"));
+        HeatRecipeBuilder.builder().input(Blocks.FURNACE).amount(3).properties(lightable).build(consumer, heatLoc("furnace"));
+        HeatRecipeBuilder.builder().input(Blocks.REDSTONE_TORCH).amount(1).properties(lightable).build(consumer, heatLoc("redstone_torch"));
     }
 
     private void registerIronOres(Consumer<IFinishedRecipe> consumer, EnumOre ore) {

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/HeatRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/HeatRegistry.java
@@ -2,8 +2,7 @@ package novamachina.exnihilosequentia.common.registries;
 
 import java.util.ArrayList;
 import java.util.List;
-import net.minecraft.util.IItemProvider;
-import net.minecraftforge.registries.ForgeRegistryEntry;
+import net.minecraft.block.BlockState;
 import novamachina.exnihilosequentia.api.crafting.heat.HeatRecipe;
 import novamachina.exnihilosequentia.api.registry.IHeatRegistry;
 import novamachina.exnihilosequentia.common.utility.ExNihiloLogger;
@@ -20,8 +19,8 @@ public class HeatRegistry implements IHeatRegistry {
     }
 
     @Override
-    public int getHeatAmount(ForgeRegistryEntry<? extends IItemProvider> entry) {
-        return recipeList.stream().filter(recipe -> recipe.getInput().getRegistryName().equals(entry.getRegistryName())).findFirst().map(HeatRecipe::getAmount).orElse(0);
+    public int getHeatAmount(BlockState entry) {
+        return recipeList.stream().filter(recipe -> recipe.isMatch(entry)).findFirst().map(HeatRecipe::getAmount).orElse(0);
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/BaseCrucibleTile.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/BaseCrucibleTile.java
@@ -4,12 +4,14 @@ import novamachina.exnihilosequentia.api.ExNihiloRegistries;
 import novamachina.exnihilosequentia.api.crafting.crucible.CrucibleRecipe;
 import novamachina.exnihilosequentia.common.utility.Config;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FlowingFluidBlock;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SUpdateTileEntityPacket;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
@@ -24,7 +26,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
-import net.minecraftforge.fluids.capability.templates.FluidTank;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import novamachina.exnihilosequentia.common.utility.ExNihiloLogger;
@@ -93,7 +94,17 @@ public abstract class BaseCrucibleTile extends TileEntity implements ITickableTi
         return super.getCapability(cap, side);
     }
 
-    public abstract int getHeat();
+    public int getHeat() {
+        BlockState source = level.getBlockState(worldPosition.below());
+        int blockHeat = ExNihiloRegistries.HEAT_REGISTRY.getHeatAmount(source);
+        if(source.getBlock() instanceof FlowingFluidBlock) {
+            int level = 8 - source.getValue(BlockStateProperties.LEVEL);
+            double partial = (double)blockHeat / 8;
+            int returnVal = (int)Math.ceil(partial * level);
+            return returnVal;
+        }
+        return blockHeat;
+    }
 
     public ActionResultType onBlockActivated(PlayerEntity player, Hand handIn,
                                              IFluidHandler handler) {

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/FiredCrucibleTile.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/FiredCrucibleTile.java
@@ -17,19 +17,6 @@ public class FiredCrucibleTile extends BaseCrucibleTile {
     }
 
     @Override
-    public int getHeat() {
-        BlockState source = level.getBlockState(worldPosition.below());
-        int blockHeat = ExNihiloRegistries.HEAT_REGISTRY.getHeatAmount(source.getBlock());
-        if(source.getBlock() instanceof FlowingFluidBlock) {
-            int level = 8 - source.getValue(BlockStateProperties.LEVEL);
-            double partial = (double)blockHeat / 8;
-            int returnVal = (int)Math.ceil(partial * level);
-            return returnVal;
-        }
-        return blockHeat;
-    }
-
-    @Override
     public CrucilbeTypeEnum getCrucibleType() {
         return CrucilbeTypeEnum.FIRED;
     }

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/WoodCrucibleTile.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/WoodCrucibleTile.java
@@ -80,15 +80,7 @@ public class WoodCrucibleTile extends BaseCrucibleTile {
 
     @Override
     public int getHeat() {
-        BlockState source = level.getBlockState(worldPosition.below());
-        int blockHeat = ExNihiloRegistries.HEAT_REGISTRY.getHeatAmount(source.getBlock());
-        if(source.getBlock() instanceof FlowingFluidBlock) {
-            int level = 8 - source.getValue(BlockStateProperties.LEVEL);
-            double partial = (double)blockHeat / 8;
-            int returnVal = Math.min((int) Math.ceil(partial * level), Config.getWoodHeatRate());
-            return returnVal;
-        }
-        return Math.max(blockHeat, Config.getWoodHeatRate());
+        return Math.max(super.getHeat(), Config.getWoodHeatRate());
     }
 
     @Override

--- a/src/main/resources/data/exnihilosequentia/recipes/heat/ens_campfire.json
+++ b/src/main/resources/data/exnihilosequentia/recipes/heat/ens_campfire.json
@@ -1,0 +1,8 @@
+{
+  "type": "exnihilosequentia:heat",
+  "block": "minecraft:campfire",
+  "amount": 4,
+  "state": {
+    "lit": "true"
+  }
+}

--- a/src/main/resources/data/exnihilosequentia/recipes/heat/ens_furnace.json
+++ b/src/main/resources/data/exnihilosequentia/recipes/heat/ens_furnace.json
@@ -1,0 +1,8 @@
+{
+  "type": "exnihilosequentia:heat",
+  "block": "minecraft:furnace",
+  "amount": 3,
+  "state": {
+    "lit": "true"
+  }
+}

--- a/src/main/resources/data/exnihilosequentia/recipes/heat/ens_redstone_torch.json
+++ b/src/main/resources/data/exnihilosequentia/recipes/heat/ens_redstone_torch.json
@@ -1,0 +1,8 @@
+{
+  "type": "exnihilosequentia:heat",
+  "block": "minecraft:redstone_torch",
+  "amount": 1,
+  "state": {
+    "lit": "true"
+  }
+}

--- a/src/main/resources/data/exnihilosequentia/recipes/heat/ens_redstone_wall_torch.json
+++ b/src/main/resources/data/exnihilosequentia/recipes/heat/ens_redstone_wall_torch.json
@@ -1,0 +1,8 @@
+{
+  "type": "exnihilosequentia:heat",
+  "block": "minecraft:redstone_wall_torch",
+  "amount": 1,
+  "state": {
+    "lit": "true"
+  }
+}

--- a/src/main/resources/data/exnihilosequentia/recipes/heat/ens_soul_campfire.json
+++ b/src/main/resources/data/exnihilosequentia/recipes/heat/ens_soul_campfire.json
@@ -1,0 +1,8 @@
+{
+  "type": "exnihilosequentia:heat",
+  "block": "minecraft:soul_campfire",
+  "amount": 4,
+  "state": {
+    "lit": "true"
+  }
+}


### PR DESCRIPTION
This pull request adds support for distinguishing if a block is a heat source not only by its resource location, but also by its state. For example, a lit campfire should provide heat to a crucible, but an unlit one should not. This was not previously possible.

This is achieved by borrowing `StatePropertiesPredicate` used elsewhere in the game.

This PR also adds lit furnaces and redstone torches to the list of available heat sources.

This change was suggested at DarkPacks/SkyFactory-One#75 and I did not check here to see if it had been suggested or addressed already before looking into it. I note that PR #259 has been opened to address this, however, that PR takes a more naive approach by allowing both lit and unlit campfires to provide heat.