### PR TITLE
Optimize Crucible isMeltable function by ~10x

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/common/registries/CrucibleRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/CrucibleRegistry.java
@@ -35,7 +35,14 @@ public class CrucibleRegistry implements ICrucibleRegistry {
 
     @Override
     public boolean isMeltable(IItemProvider item, int level) {
-        boolean result = recipeList.stream().anyMatch(recipe -> recipe.getInput().test(new ItemStack(item)) && recipe.getCrucibleType().getLevel() <= level);
+        ItemStack itemStack = new ItemStack(item);
+        boolean result = false;
+        for (CrucibleRecipe recipe : recipeList) {
+            if (recipe.getInput().test(itemStack) && recipe.getCrucibleType().getLevel() <= level) {
+                result = true;
+                break;
+            }
+        }
         return result;
     }
 


### PR DESCRIPTION
This pull request optimizes is crucible isMeltable function by around 10x
this was tested with a void world containing 128 crucibles that have cobblestone continually inserted via hoppers (the crucibles have no heat source) 
random ticks & mob spawning and daylight cycle disabled for consistent testing 

the original implementation of this function is quite performance heavy as shown here in this tick profile 
![image](https://user-images.githubusercontent.com/36360408/138529791-fb99b6f6-af63-4c0f-8fc7-7fcd0f399fac.png)

https://spark.lucko.me/0uWlhY76he
it spends a lot of its time creating ItemStack objects and the rest is overhead from the java streams interface  

after this small optimization to cache the ItemStack object and to replace streams with a for loop the overall execution time for ExNihiloSequentia in the world dropped to ~200ms from ~2000ms as shown in the tick profile shown below
![image](https://user-images.githubusercontent.com/36360408/138529765-e8c04cfc-f570-481e-aefa-cd40f356df5b.png)

https://spark.lucko.me/nYrS7rAHRf

The following tick profile shows the affect of just caching the ItemStack object rather then creating it inside of the function used for anyMatch

![image](https://user-images.githubusercontent.com/36360408/138530226-90733c39-7349-4481-b839-1ed1cb8fb61a.png)
https://spark.lucko.me/IfuqGMUx1J

I would like to stress here that while this may seem like a small optimization in this test setup
in a real situation with other mods that may be trying to insert items every tick this optimization matters more

all tick profiles taken in the same world at the same position over a 60 second window

testing this in a real world case (in this case my skyfactory one server) shows a drop from 16.5mspt to 8.7mspt