### PR TITLE
Include Sweet Berries as a valid compost recipe.

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/common/datagen/ExNihiloRecipeGenerator.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/datagen/ExNihiloRecipeGenerator.java
@@ -118,6 +118,7 @@ public class ExNihiloRecipeGenerator extends AbstractRecipeGenerator {
         createCompostRecipe(consumer, ExNihiloItems.SILKWORM.get(), 40, "silkworm");
         createCompostRecipe(consumer, ExNihiloItems.COOKED_SILKWORM.get(), 40, "cooked_silkworm");
         createCompostRecipe(consumer, Items.APPLE, 100, "apple");
+        createCompostRecipe(consumer, Items.SWEET_BERRIES, 100, "sweet_berries");
         createCompostRecipe(consumer, Items.MELON_SLICE, 40, "melon_slice");
         createCompostRecipe(consumer, Items.MELON, 1000 / 6, "melon");
         createCompostRecipe(consumer, Items.PUMPKIN, 1000 / 6, "pumpkin");

--- a/src/main/resources/data/exnihilosequentia/recipes/compost/ens_sweet_berries.json
+++ b/src/main/resources/data/exnihilosequentia/recipes/compost/ens_sweet_berries.json
@@ -1,0 +1,7 @@
+{
+  "type": "exnihilosequentia:compost",
+  "input": {
+    "item": "minecraft:sweet_berries"
+  },
+  "amount": 100
+}


### PR DESCRIPTION
### Why:

While playing the **SkyFactory One** modpack I run out of saplings, but I had some **Sweet Berries** seeds and **Dirt** 
 that I could use to grow **Sweet Berries**, make new dirt by composing the berries, and then sieve the dirt to get new saplings... Then I tried to compost sweet berries, it wasn't possible and I had to reset the map.

_That's a true story I swear._

### What this does:

* Includes the Sweet Berries as a valid compost recipe.

**That's it, have a great day. 👋**