### PR TITLE
Less intrusive particles on Barrels.

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/barrel/mode/CompostBarrelMode.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/barrel/mode/CompostBarrelMode.java
@@ -1,10 +1,6 @@
 package novamachina.exnihilosequentia.common.tileentity.barrel.mode;
 
-import novamachina.exnihilosequentia.api.ExNihiloRegistries;
-import novamachina.exnihilosequentia.common.tileentity.barrel.AbstractBarrelTile;
-import novamachina.exnihilosequentia.common.utility.Config;
-import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
-import novamachina.exnihilosequentia.common.utility.StringUtils;
+import com.google.common.base.Preconditions;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -18,6 +14,11 @@ import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.registries.ForgeRegistries;
+import novamachina.exnihilosequentia.api.ExNihiloRegistries;
+import novamachina.exnihilosequentia.common.tileentity.barrel.AbstractBarrelTile;
+import novamachina.exnihilosequentia.common.utility.Config;
+import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
+import novamachina.exnihilosequentia.common.utility.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -87,16 +88,17 @@ public class CompostBarrelMode extends AbstractBarrelMode {
     @Override
     protected void spawnParticle(AbstractBarrelTile barrelTile) {
         if (Config.getShowParticles()) {
-            ((ServerWorld) barrelTile.getLevel())
-                    .sendParticles(ParticleTypes.EFFECT,
-                            barrelTile.getBlockPos().getX() + barrelTile.getLevel().random.nextDouble(),
-                            barrelTile.getBlockPos().getY() + barrelTile.getLevel().random.nextDouble(),
-                            barrelTile.getBlockPos().getZ() + barrelTile.getLevel().random.nextDouble(),
-                            1,
-                            0.0,
-                            0.0,
-                            0.0,
-                            0.05);
+            ServerWorld level = (ServerWorld) barrelTile.getLevel();
+            Preconditions.checkNotNull(level, "Level is null.");
+            level.sendParticles(ParticleTypes.ASH,
+                    barrelTile.getBlockPos().getX() + (.2d + (.8d - .2d) * level.random.nextDouble()),
+                    barrelTile.getBlockPos().getY() + 1.2d,
+                    barrelTile.getBlockPos().getZ() + (.2d + (.8d - .2d) * level.random.nextDouble()),
+                    1,
+                    0,
+                    0,
+                    0,
+                    0.01);
         }
     }
 

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/barrel/mode/FluidTransformBarrelMode.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/barrel/mode/FluidTransformBarrelMode.java
@@ -1,5 +1,6 @@
 package novamachina.exnihilosequentia.common.tileentity.barrel.mode;
 
+import com.google.common.base.Preconditions;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.ItemStack;
@@ -85,16 +86,17 @@ public class FluidTransformBarrelMode extends AbstractBarrelMode {
 
     @Override
     protected void spawnParticle(AbstractBarrelTile barrelTile) {
-        ((ServerWorld) barrelTile.getLevel())
-            .sendParticles(ParticleTypes.EFFECT,
-                barrelTile.getBlockPos().getX() + barrelTile.getLevel().random.nextDouble(),
-                barrelTile.getBlockPos().getY() + barrelTile.getLevel().random.nextDouble(),
-                barrelTile.getBlockPos().getZ() + barrelTile.getLevel().random.nextDouble(),
+        ServerWorld level = (ServerWorld) barrelTile.getLevel();
+        Preconditions.checkNotNull(level, "Level is null.");
+        level.sendParticles(ParticleTypes.ASH,
+                barrelTile.getBlockPos().getX() + (.2d + (.8d - .2d) * level.random.nextDouble()),
+                barrelTile.getBlockPos().getY() + 1.2d,
+                barrelTile.getBlockPos().getZ() + (.2d + (.8d - .2d) * level.random.nextDouble()),
                 1,
-                0.0,
-                0.0,
-                0.0,
-                0.05);
+                0,
+                0,
+                0,
+                0.01);
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/barrel/mode/FluidTransformBarrelMode.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/barrel/mode/FluidTransformBarrelMode.java
@@ -88,15 +88,15 @@ public class FluidTransformBarrelMode extends AbstractBarrelMode {
     protected void spawnParticle(AbstractBarrelTile barrelTile) {
         ServerWorld level = (ServerWorld) barrelTile.getLevel();
         Preconditions.checkNotNull(level, "Level is null.");
-        level.sendParticles(ParticleTypes.ASH,
-                barrelTile.getBlockPos().getX() + (.2d + (.8d - .2d) * level.random.nextDouble()),
-                barrelTile.getBlockPos().getY() + 1.2d,
-                barrelTile.getBlockPos().getZ() + (.2d + (.8d - .2d) * level.random.nextDouble()),
+        level.sendParticles(ParticleTypes.EFFECT,
+                barrelTile.getBlockPos().getX() + barrelTile.getLevel().random.nextDouble(),
+                barrelTile.getBlockPos().getY() + barrelTile.getLevel().random.nextDouble(),
+                barrelTile.getBlockPos().getZ() + barrelTile.getLevel().random.nextDouble(),
                 1,
                 0,
                 0,
                 0,
-                0.01);
+                0.05);
     }
 
     @Override
@@ -104,7 +104,7 @@ public class FluidTransformBarrelMode extends AbstractBarrelMode {
         List<ITextComponent> info = new ArrayList<>();
 
         info.add(new TranslationTextComponent("waila.progress", StringUtils
-            .formatPercent((float) currentProgress / (Config.getSecondsToFluidTransform() * 20))));
+                .formatPercent((float) currentProgress / (Config.getSecondsToFluidTransform() * 20))));
 
         return info;
     }


### PR DESCRIPTION
### Why:

While playing the **SkyFactory One** modpack I had to use a big quantity of barrels to speed the dirt transformation, this made the barrel spawn a lot of particles and they were everywhere. 

I know that I can disable them, but I thought of making them look better.

### What was done:

* Changed the particle type, where the particle spawns, and the speed.
* Added some null checking because JAVA loves null checking.
* These changes are applied to the **CompostMode and FluidTransformMode**.

#### Old vs New:
![fx_0](https://user-images.githubusercontent.com/52864251/138915093-d7f9009a-1086-45a5-a0bc-184a0d8e0854.gif)![fx_1](https://user-images.githubusercontent.com/52864251/138915204-5963ad5a-f423-40c3-8142-1201302f1562.gif)
 