### PR TITLE
Added caching, prevented created ItemStacks where possible and simplified use of Streams.

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/api/registry/ICrucibleRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/api/registry/ICrucibleRegistry.java
@@ -1,6 +1,8 @@
 package novamachina.exnihilosequentia.api.registry;
 
 import java.util.List;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.IItemProvider;
 import novamachina.exnihilosequentia.api.crafting.crucible.CrucibleRecipe;
 
@@ -9,9 +11,17 @@ public interface ICrucibleRegistry {
 
     CrucibleRecipe findRecipe(IItemProvider item);
 
+    CrucibleRecipe findRecipeByItemStack(ItemStack itemStack);
+
+    CrucibleRecipe findRecipeByItem(Item item);
+
     List<CrucibleRecipe> getRecipeList();
 
     boolean isMeltable(IItemProvider item, int level);
+
+    boolean isMeltableByItem(Item item, int level);
+
+    boolean isMeltableByItemStack(ItemStack item, int level);
 
     void setRecipes(List<CrucibleRecipe> recipes);
 }

--- a/src/main/java/novamachina/exnihilosequentia/common/compat/jei/crucible/FiredCrucibleTooltipCallback.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/compat/jei/crucible/FiredCrucibleTooltipCallback.java
@@ -12,7 +12,7 @@ public class FiredCrucibleTooltipCallback implements ITooltipCallback<ItemStack>
     @Override
     public void onTooltip(int slotIndex, boolean input, ItemStack ingredient, List<ITextComponent> tooltip) {
         if (input) {
-            CrucibleRecipe meltable = ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(ingredient.getItem());
+            CrucibleRecipe meltable = ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(ingredient);
             tooltip.add(new StringTextComponent(String.format("Fluid Amount: %d mb", meltable.getAmount())));
         }
     }

--- a/src/main/java/novamachina/exnihilosequentia/common/compat/jei/crucible/WoodCrucibleTooltipCallback.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/compat/jei/crucible/WoodCrucibleTooltipCallback.java
@@ -12,7 +12,7 @@ public class WoodCrucibleTooltipCallback implements ITooltipCallback<ItemStack> 
     @Override
     public void onTooltip(int slotIndex, boolean input, ItemStack ingredient, List<ITextComponent> tooltip) {
         if (input) {
-            CrucibleRecipe meltable = ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(ingredient.getItem());
+            CrucibleRecipe meltable = ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(ingredient);
             tooltip.add(new StringTextComponent(String.format("Fluid Amount: %d mb", meltable.getAmount())));
         }
     }

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/CompostRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/CompostRegistry.java
@@ -1,5 +1,6 @@
 package novamachina.exnihilosequentia.common.registries;
 
+import net.minecraft.item.Item;
 import novamachina.exnihilosequentia.api.crafting.compost.CompostRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IItemProvider;
@@ -8,30 +9,33 @@ import novamachina.exnihilosequentia.common.utility.ExNihiloLogger;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class CompostRegistry implements ICompostRegistry {
     private static final ExNihiloLogger logger = new ExNihiloLogger(LogManager.getLogger());
     public final List<CompostRecipe> recipeList = new ArrayList<>();
 
+    private final Map<Item, Integer> itemSolidAmountCache = new HashMap<>();
+
     @Override
     public boolean containsSolid(IItemProvider item) {
-        for(CompostRecipe recipe : recipeList) {
-            if(recipe.getInput().test(new ItemStack(item))) {
-                return true;
-            }
-        }
-        return false;
+        return getSolidAmount(item) > 0;
     }
 
     @Override
     public int getSolidAmount(IItemProvider item) {
-        for(CompostRecipe recipe : recipeList) {
-            if(recipe.getInput().test(new ItemStack(item))) {
-                return recipe.getAmount();
-            }
-        }
-        return 0;
+        return itemSolidAmountCache
+                .computeIfAbsent(item.asItem(), k -> {
+                    final ItemStack itemStack = new ItemStack(item);
+                    return recipeList
+                            .stream()
+                            .filter(compostRecipe -> compostRecipe.getInput().test(itemStack))
+                            .findFirst()
+                            .map(CompostRecipe::getAmount)
+                            .orElse(0);
+                });
     }
 
     @Override
@@ -48,5 +52,7 @@ public class CompostRegistry implements ICompostRegistry {
     @Override
     public void clearRecipes() {
         recipeList.clear();
+
+        itemSolidAmountCache.clear();
     }
 }

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/CompostRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/CompostRegistry.java
@@ -42,6 +42,8 @@ public class CompostRegistry implements ICompostRegistry {
     public void setRecipes(List<CompostRecipe> recipes) {
         logger.debug("Compost Registry recipes: " + recipes.size());
         this.recipeList.addAll(recipes);
+
+        itemSolidAmountCache.clear();
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/CrookRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/CrookRegistry.java
@@ -45,6 +45,8 @@ public class CrookRegistry implements ICrookRegistry {
     public void setRecipes(List<CrookRecipe> recipes) {
         logger.debug("Crook Registry recipes: " + recipes.size());
         recipeList.addAll(recipes);
+
+        recipeListByItemCache.clear();
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/CrookRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/CrookRegistry.java
@@ -10,7 +10,10 @@ import novamachina.exnihilosequentia.api.registry.ICrookRegistry;
 import novamachina.exnihilosequentia.common.utility.ExNihiloLogger;
 import org.apache.logging.log4j.LogManager;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/FluidItemTransformRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/FluidItemTransformRegistry.java
@@ -1,5 +1,7 @@
 package novamachina.exnihilosequentia.common.registries;
 
+import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidStack;
 import novamachina.exnihilosequentia.api.crafting.fluiditem.FluidItemRecipe;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
@@ -10,31 +12,34 @@ import novamachina.exnihilosequentia.common.utility.ExNihiloLogger;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class FluidItemTransformRegistry implements IFluidItemTransformRegistry {
     private static final ExNihiloLogger logger = new ExNihiloLogger(LogManager.getLogger());
 
     private final List<FluidItemRecipe> recipeList = new ArrayList<>();
 
+    private final Item empty = ItemStack.EMPTY.getItem();
+    private final Map<FluidStack, Map<Item, Item>> itemResultCache = new HashMap<>();
+
     @Override
     public boolean isValidRecipe(Fluid fluid, Item input) {
-        for (FluidItemRecipe recipe : recipeList) {
-            if(recipe.validInputs(fluid, input)) {
-                return true;
-            }
-        }
-        return false;
+        return getResult(fluid, input) != empty;
     }
 
     @Override
     public IItemProvider getResult(Fluid fluid, Item input) {
-        for (FluidItemRecipe recipe : recipeList) {
-            if (recipe.validInputs(fluid, input)) {
-                return recipe.getResultItem().getItem();
-            }
-        }
-        return ItemStack.EMPTY.getItem();
+        return itemResultCache
+                .computeIfAbsent(new FluidStack(fluid, FluidAttributes.BUCKET_VOLUME), k -> new HashMap<>())
+                .computeIfAbsent(input, k -> recipeList
+                        .stream()
+                        .filter(fluidItemRecipe -> fluidItemRecipe.validInputs(fluid, input))
+                        .findFirst()
+                        .map(FluidItemRecipe::getResultItem)
+                        .map(ItemStack::getItem)
+                        .orElse(empty));
     }
 
     @Override
@@ -51,5 +56,7 @@ public class FluidItemTransformRegistry implements IFluidItemTransformRegistry {
     @Override
     public void clearRecipes() {
         recipeList.clear();
+
+        itemResultCache.clear();
     }
 }

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/FluidItemTransformRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/FluidItemTransformRegistry.java
@@ -51,6 +51,8 @@ public class FluidItemTransformRegistry implements IFluidItemTransformRegistry {
     public void setRecipes(List<FluidItemRecipe> recipes) {
         logger.debug("Fluid Item Transform Registry recipes: " + recipes.size());
         recipeList.addAll(recipes);
+
+        itemResultCache.clear();
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/FluidOnTopRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/FluidOnTopRegistry.java
@@ -55,6 +55,8 @@ public class FluidOnTopRegistry implements IFluidOnTopRegistry {
     public void setRecipes(List<FluidOnTopRecipe> recipes) {
         logger.debug("Fluid On Top Registry recipes: " + recipes.size());
         recipeList.addAll(recipes);
+
+        itemResultCache.clear();
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/FluidTransformRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/FluidTransformRegistry.java
@@ -55,6 +55,8 @@ public class FluidTransformRegistry implements IFluidTransformRegistry {
     public void setRecipes(List<FluidTransformRecipe> recipes) {
         logger.debug("Fluid Transform Registry recipes: " + recipes.size());
         recipeList.addAll(recipes);
+
+        fluidResultCache.clear();
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/FluidTransformRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/FluidTransformRegistry.java
@@ -2,7 +2,6 @@ package novamachina.exnihilosequentia.common.registries;
 
 import net.minecraft.util.IItemProvider;
 import novamachina.exnihilosequentia.api.crafting.fluidtransform.FluidTransformRecipe;
-import net.minecraft.block.Block;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.item.ItemStack;
@@ -13,31 +12,38 @@ import novamachina.exnihilosequentia.common.utility.ExNihiloLogger;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class FluidTransformRegistry implements IFluidTransformRegistry {
     private static final ExNihiloLogger logger = new ExNihiloLogger(LogManager.getLogger());
 
     private final List<FluidTransformRecipe> recipeList = new ArrayList<>();
 
+    private final Map<FluidStack, Map<IItemProvider, Fluid>> fluidResultCache = new HashMap<>();
+
     @Override
     public boolean isValidRecipe(Fluid fluidInTank, IItemProvider catalyst) {
-        for(FluidTransformRecipe recipe : recipeList) {
-            if(recipe.getFluidInTank().isFluidEqual(new FluidStack(fluidInTank, FluidAttributes.BUCKET_VOLUME)) && recipe.getCatalyst().test(new ItemStack(catalyst))) {
-                return true;
-            }
-        }
-        return false;
+        return getResult(fluidInTank, catalyst) != Fluids.EMPTY;
     }
 
     @Override
     public Fluid getResult(Fluid fluidInTank, IItemProvider catalyst) {
-        for(FluidTransformRecipe recipe : recipeList) {
-            if(recipe.getFluidInTank().isFluidEqual(new FluidStack(fluidInTank, FluidAttributes.BUCKET_VOLUME)) && recipe.getCatalyst().test(new ItemStack(catalyst))) {
-                return recipe.getResult().getFluid();
-            }
-        }
-        return Fluids.EMPTY;
+        final FluidStack fluidStack = new FluidStack(fluidInTank, FluidAttributes.BUCKET_VOLUME);
+        return fluidResultCache
+                .computeIfAbsent(fluidStack, k -> new HashMap<>())
+                .computeIfAbsent(catalyst.asItem(), k -> {
+                    final ItemStack itemStack = new ItemStack(catalyst);
+                    return recipeList
+                            .stream()
+                            .filter(fluidTransformRecipe -> fluidTransformRecipe.getFluidInTank().isFluidEqual(fluidStack))
+                            .filter(fluidTransformRecipe -> fluidTransformRecipe.getCatalyst().test(itemStack))
+                            .findFirst()
+                            .map(FluidTransformRecipe::getResult)
+                            .map(FluidStack::getFluid)
+                            .orElse(Fluids.EMPTY);
+                });
     }
 
     @Override
@@ -54,5 +60,7 @@ public class FluidTransformRegistry implements IFluidTransformRegistry {
     @Override
     public void clearRecipes() {
         recipeList.clear();
+
+        fluidResultCache.clear();
     }
 }

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/HammerRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/HammerRegistry.java
@@ -48,6 +48,8 @@ public class HammerRegistry implements IHammerRegistry {
     public void setRecipes(List<HammerRecipe> recipes) {
         logger.debug("Hammer Registry recipes: " + recipes.size());
         recipeList.addAll(recipes);
+
+        recipeByBlockCache.clear();
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/HeatRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/HeatRegistry.java
@@ -20,7 +20,12 @@ public class HeatRegistry implements IHeatRegistry {
 
     @Override
     public int getHeatAmount(BlockState entry) {
-        return recipeList.stream().filter(recipe -> recipe.isMatch(entry)).findFirst().map(HeatRecipe::getAmount).orElse(0);
+        return recipeList
+                .stream()
+                .filter(recipe -> recipe.isMatch(entry))
+                .findFirst()
+                .map(HeatRecipe::getAmount)
+                .orElse(0);
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/SieveRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/SieveRegistry.java
@@ -141,6 +141,9 @@ public class SieveRegistry implements ISieveRegistry {
     public void setRecipes(List<SieveRecipe> recipes) {
         logger.debug("Sieve Registry recipes: " + recipes.size());
         recipeList.addAll(recipes);
+
+        blockSiftableCache.clear();
+        itemDropsListCache.clear();
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/SieveRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/SieveRegistry.java
@@ -9,11 +9,11 @@ import novamachina.exnihilosequentia.common.item.mesh.EnumMesh;
 import novamachina.exnihilosequentia.common.item.ore.OreItem;
 import novamachina.exnihilosequentia.common.utility.Config;
 import novamachina.exnihilosequentia.common.utility.ExNihiloLogger;
+import novamachina.exnihilosequentia.common.utility.IngredientUtils;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.IItemProvider;
-import novamachina.exnihilosequentia.common.utility.IngredientUtils;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;

--- a/src/main/java/novamachina/exnihilosequentia/common/registries/SieveRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/SieveRegistry.java
@@ -1,7 +1,7 @@
 package novamachina.exnihilosequentia.common.registries;
 
 import com.google.common.collect.Lists;
-import novamachina.exnihilosequentia.api.crafting.sieve.MeshWithChance;
+import net.minecraft.item.Item;
 import novamachina.exnihilosequentia.api.crafting.sieve.SieveRecipe;
 import novamachina.exnihilosequentia.api.registry.ISieveRegistry;
 import novamachina.exnihilosequentia.api.compat.jei.JEISieveRecipe;
@@ -9,18 +9,20 @@ import novamachina.exnihilosequentia.common.item.mesh.EnumMesh;
 import novamachina.exnihilosequentia.common.item.ore.OreItem;
 import novamachina.exnihilosequentia.common.utility.Config;
 import novamachina.exnihilosequentia.common.utility.ExNihiloLogger;
-import novamachina.exnihilosequentia.common.utility.IngredientUtils;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.IItemProvider;
+import novamachina.exnihilosequentia.common.utility.IngredientUtils;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,139 +31,110 @@ public class SieveRegistry implements ISieveRegistry {
 
     private final boolean flattenRecipes = Config.flattenSieveRecipes();
 
-    private List<SieveRecipe> recipeList = new ArrayList<>();
+    private final List<SieveRecipe> recipeList = new ArrayList<>();
 
-    private List<SieveRecipe> getDrops(Ingredient input, EnumMesh meshType, boolean isWaterlogged) {
-        return recipeList.parallelStream()
-            .filter(sieveRecipe -> sieveRecipe.isWaterlogged() == isWaterlogged)
-            .filter(sieveRecipe -> IngredientUtils.areIngredientsEqual(sieveRecipe.getInput(), input))
-            .map(recipe -> recipe.filterByMesh(meshType, flattenRecipes))
-            .filter(recipe -> {
-                if(recipe.getDrop().getItem() instanceof OreItem) {
-                    OreItem ore = (OreItem)recipe.getDrop().getItem();
-                    if(!ore.getOre().isEnabled()) {
-                        return false;
-                    }
-                }
-                return true;
-            })
-            .filter(recipe -> !recipe.getRolls().isEmpty())
-            .collect(Collectors.toList());
+    private final Map<Boolean, Map<EnumMesh, Map<Block, Boolean>>> blockSiftableCache = new HashMap<>();
+    private final Map<Boolean, Map<EnumMesh, Map<Item, List<SieveRecipe>>>> itemDropsListCache = new HashMap<>();
+
+    private List<SieveRecipe> getDropsByIngredient(Ingredient input, EnumMesh meshType, boolean isWaterlogged) {
+        return Arrays.stream(input.getItems())
+                .map(ItemStack::getItem)
+                .flatMap(item -> getDrops(item, meshType, isWaterlogged).stream())
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<SieveRecipe> getDrops(IItemProvider input, EnumMesh meshType, boolean isWaterlogged) {
-        return recipeList.parallelStream()
-            .filter(sieveRecipe -> sieveRecipe.isWaterlogged() == isWaterlogged)
-            .filter(sieveRecipe -> sieveRecipe.getInput().test(new ItemStack(input)))
-            .map(recipe -> recipe.filterByMesh(meshType, flattenRecipes))
-            .filter(recipe -> {
-                if(recipe.getDrop().getItem() instanceof OreItem) {
-                    OreItem ore = (OreItem)recipe.getDrop().getItem();
-                    if(!ore.getOre().isEnabled()) {
-                        return false;
-                    }
-                }
-                return true;
-            })
-            .filter(recipe -> !recipe.getRolls().isEmpty())
-            .collect(Collectors.toList());
+        return itemDropsListCache
+                .computeIfAbsent(isWaterlogged, k -> new HashMap<>())
+                .computeIfAbsent(meshType, k -> new HashMap<>())
+                .computeIfAbsent(input.asItem(), k -> {
+                    final ItemStack itemStack = new ItemStack(k);
+                    return recipeList.stream()
+                            .filter(sieveRecipe -> sieveRecipe.isWaterlogged() == isWaterlogged)
+                            .filter(sieveRecipe -> sieveRecipe.getInput().test(itemStack))
+                            .map(recipe -> recipe.filterByMesh(meshType, flattenRecipes))
+                            .filter(recipe -> !recipe.getRolls().isEmpty())
+                            .filter(recipe -> {
+                                if (recipe.getDrop().getItem() instanceof OreItem) {
+                                    final OreItem ore = (OreItem)recipe.getDrop().getItem();
+                                    return ore.getOre().isEnabled();
+                                }
+                                return true;
+                            })
+                            .collect(Collectors.toList());
+                });
     }
 
     @Override
     public boolean isBlockSiftable(Block block, EnumMesh mesh, boolean isWaterlogged) {
-        return recipeList.parallelStream().anyMatch(sieveRecipe ->{
-            if(sieveRecipe.getInput().test(new ItemStack(block)) && sieveRecipe.isWaterlogged() == isWaterlogged) {
-                for(MeshWithChance meshWithChance : sieveRecipe.getRolls()) {
-                    if(flattenRecipes) {
-                        if(meshWithChance.getMesh().getId() <= mesh.getId()) {
-                            return true;
-                        }
-                    } else {
-                        if(meshWithChance.getMesh().getId() == mesh.getId()) {
-                            return true;
-                        }
+        return blockSiftableCache
+                .computeIfAbsent(isWaterlogged, k -> new HashMap<>())
+                .computeIfAbsent(mesh, k -> new HashMap<>())
+                .computeIfAbsent(block, k -> {
+                    final ItemStack itemStack = new ItemStack(block);
+                    final int meshId = mesh.getId();
+                    return recipeList
+                            .stream()
+                            .filter(sieveRecipe -> sieveRecipe.isWaterlogged() == isWaterlogged)
+                            .filter(sieveRecipe -> sieveRecipe.getInput().test(itemStack))
+                            .anyMatch(sieveRecipe -> sieveRecipe
+                                    .getRolls()
+                                    .stream()
+                                    .anyMatch(meshWithChance -> {
+                                        final int meshWithChanceId = meshWithChance.getMesh().getId();
+                                        if (flattenRecipes)
+                                            return meshWithChanceId <= meshId;
+                                        else
+                                            return meshWithChanceId == meshId;
+                                    }));
+                });
+    }
+
+    private List<JEISieveRecipe> getRecipeList(boolean isWaterLogged) {
+        final Set<Ingredient> ingredients = new HashSet<>();
+        recipeList
+                .forEach(recipe -> {
+                    final Ingredient recipeIngredient = recipe.getInput();
+                    if (ingredients
+                            .stream()
+                            .noneMatch(ingredient ->
+                                    IngredientUtils.areIngredientsEqual(ingredient, recipeIngredient))) {
+                        ingredients.add(recipeIngredient);
                     }
-                }
-            }
-            return false;
-        });
+                });
+
+        return Arrays.stream(EnumMesh.values())
+                .filter(enumMesh -> enumMesh != EnumMesh.NONE)
+                .flatMap(enumMesh -> {
+                    final ItemStack mesh = new ItemStack(enumMesh.getRegistryObject().get());
+                    return ingredients
+                            .stream()
+                            .flatMap(ingredient -> {
+                                final List<SieveRecipe> drops = getDropsByIngredient(ingredient, enumMesh, isWaterLogged);
+                                if (drops.isEmpty())
+                                    return null;
+                                final List<List<ItemStack>> input = new ArrayList<>(Arrays.asList(
+                                        Collections.singletonList(mesh),
+                                        Arrays.asList(ingredient.getItems())
+                                ));
+                                return Lists
+                                        .partition(drops, 21)
+                                        .stream()
+                                        .map(results -> new JEISieveRecipe(input, results));
+                            });
+                })
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<JEISieveRecipe> getDryRecipeList() {
-        List<JEISieveRecipe> returnList = new ArrayList<>();
-
-        Set<Ingredient> inputs = new HashSet<>();
-        for(SieveRecipe recipe : recipeList) {
-            boolean insert = true;
-            for(Ingredient ingredient : inputs) {
-                if(IngredientUtils.areIngredientsEqual(ingredient, recipe.getInput())) {
-                    insert = false;
-                    break;
-                }
-            }
-            if(insert) {
-                inputs.add(recipe.getInput());
-            }
-        }
-
-        for(EnumMesh mesh : EnumMesh.values()) {
-            if(mesh != EnumMesh.NONE) {
-                for(Ingredient ingredient : inputs) {
-                    List<SieveRecipe> drops = getDrops(ingredient, mesh, false);
-                    List<List<SieveRecipe>> dropLists = Lists.partition(drops, 21);
-                    if(!drops.isEmpty()) {
-                        List<List<ItemStack>> inputList = new ArrayList<>();
-                        inputList.add(Collections.singletonList(new ItemStack(mesh.getRegistryObject().get())));
-                        inputList.add(Arrays.asList(ingredient.getItems()));
-                        for(List<SieveRecipe> dropList : dropLists) {
-                            returnList.add(new JEISieveRecipe(inputList, dropList));
-                        }
-                    }
-                }
-            }
-        }
-
-        return returnList;
+        return getRecipeList(false);
     }
 
     @Override
     public List<JEISieveRecipe> getWetRecipeList() {
-        List<JEISieveRecipe> returnList = new ArrayList<>();
-
-        Set<Ingredient> inputs = new HashSet<>();
-        for(SieveRecipe recipe : recipeList) {
-            boolean insert = true;
-            for(Ingredient ingredient : inputs) {
-                if(IngredientUtils.areIngredientsEqual(ingredient, recipe.getInput())) {
-                    insert = false;
-                    break;
-                }
-            }
-            if(insert) {
-                inputs.add(recipe.getInput());
-            }
-        }
-
-        for(EnumMesh mesh : EnumMesh.values()) {
-            if(mesh != EnumMesh.NONE) {
-                for(Ingredient ingredient : inputs) {
-                    List<SieveRecipe> drops = getDrops(ingredient, mesh, true);
-                    List<List<SieveRecipe>> dropLists = Lists.partition(drops, 21);
-                    if(!drops.isEmpty()) {
-                        List<List<ItemStack>> inputList = new ArrayList<>();
-                        inputList.add(Collections.singletonList(new ItemStack(mesh.getRegistryObject().get())));
-                        inputList.add(Arrays.asList(ingredient.getItems()));
-                        for(List<SieveRecipe> dropList : dropLists) {
-                            returnList.add(new JEISieveRecipe(inputList, dropList));
-                        }
-                    }
-                }
-            }
-        }
-
-        return returnList;
+        return getRecipeList(true);
     }
 
     @Override
@@ -173,5 +146,8 @@ public class SieveRegistry implements ISieveRegistry {
     @Override
     public void clearRecipes() {
         recipeList.clear();
+
+        blockSiftableCache.clear();
+        itemDropsListCache.clear();
     }
 }

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/BaseCrucibleTile.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/BaseCrucibleTile.java
@@ -242,7 +242,7 @@ public abstract class BaseCrucibleTile extends TileEntity implements ITickableTi
     public abstract CrucilbeTypeEnum getCrucibleType();
 
     private CrucibleRecipe getMeltable() {
-        return ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem());
+        return ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem);
     }
 
     public int getFluidAmount() {

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/FiredCrucibleTile.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/FiredCrucibleTile.java
@@ -25,7 +25,7 @@ public class FiredCrucibleTile extends BaseCrucibleTile {
     public int getSolidAmount() {
         if (!currentItem.isEmpty()) {
             int itemCount = inventory.getStackInSlot(0).getCount();
-            return solidAmount + (itemCount * ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem())
+            return solidAmount + (itemCount * ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem)
                 .getAmount());
         }
         return solidAmount;
@@ -61,7 +61,7 @@ public class FiredCrucibleTile extends BaseCrucibleTile {
                         inventory.setStackInSlot(0, ItemStack.EMPTY);
                     }
 
-                    solidAmount = ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem())
+                    solidAmount = ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem)
                         .getAmount();
                 } else {
                     return;
@@ -71,7 +71,7 @@ public class FiredCrucibleTile extends BaseCrucibleTile {
             if (!inventory.getStackInSlot(0).isEmpty() && inventory.getStackInSlot(0)
                 .sameItem(currentItem)) {
                 while (heat > solidAmount && !inventory.getStackInSlot(0).isEmpty()) {
-                    solidAmount += ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem())
+                    solidAmount += ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem)
                         .getAmount();
                     inventory.getStackInSlot(0).shrink(1);
 
@@ -86,9 +86,9 @@ public class FiredCrucibleTile extends BaseCrucibleTile {
             }
 
             if (heat > 0 && ExNihiloRegistries.CRUCIBLE_REGISTRY
-                .isMeltable(currentItem.getItem(), getCrucibleType().getLevel())) {
+                .isMeltableByItemStack(currentItem, getCrucibleType().getLevel())) {
                 FluidStack fluidStack = new FluidStack(
-                    ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem()).getResultFluid(), heat);
+                    ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem).getResultFluid(), heat);
                 int filled = tank.fill(fluidStack, FluidAction.EXECUTE);
                 solidAmount -= filled;
             }

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/MeltableItemHandler.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/MeltableItemHandler.java
@@ -33,7 +33,7 @@ public class MeltableItemHandler extends ItemStackHandler {
 
     @Override
     public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
-        return ExNihiloRegistries.CRUCIBLE_REGISTRY.isMeltable(stack.getItem(), type.getLevel());
+        return ExNihiloRegistries.CRUCIBLE_REGISTRY.isMeltableByItemStack(stack, type.getLevel());
     }
 
     @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/WoodCrucibleTile.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/tileentity/crucible/WoodCrucibleTile.java
@@ -43,7 +43,7 @@ public class WoodCrucibleTile extends BaseCrucibleTile {
                         inventory.setStackInSlot(0, ItemStack.EMPTY);
                     }
 
-                    solidAmount = ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem())
+                    solidAmount = ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem)
                         .getAmount();
                 } else {
                     return;
@@ -53,7 +53,7 @@ public class WoodCrucibleTile extends BaseCrucibleTile {
             if (!inventory.getStackInSlot(0).isEmpty() && inventory.getStackInSlot(0)
                 .sameItem(currentItem)) {
                 while (heat > solidAmount && !inventory.getStackInSlot(0).isEmpty()) {
-                    solidAmount += ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem())
+                    solidAmount += ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem)
                         .getAmount();
                     inventory.getStackInSlot(0).shrink(1);
 
@@ -68,9 +68,9 @@ public class WoodCrucibleTile extends BaseCrucibleTile {
             }
 
             if (heat > 0 && ExNihiloRegistries.CRUCIBLE_REGISTRY
-                .isMeltable(currentItem.getItem(), getCrucibleType().getLevel())) {
+                .isMeltableByItemStack(currentItem, getCrucibleType().getLevel())) {
                 FluidStack fluidStack = new FluidStack(
-                    ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem()).getResultFluid(), heat);
+                    ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem).getResultFluid(), heat);
                 int filled = tank.fill(fluidStack, FluidAction.EXECUTE);
                 solidAmount -= filled;
             }
@@ -93,7 +93,7 @@ public class WoodCrucibleTile extends BaseCrucibleTile {
         if(!currentItem.isEmpty()) {
             int itemCount = inventory.getStackInSlot(0).getCount();
             return solidAmount +
-                    (itemCount * ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipe(currentItem.getItem())
+                    (itemCount * ExNihiloRegistries.CRUCIBLE_REGISTRY.findRecipeByItemStack(currentItem)
                             .getAmount());
         }
         return solidAmount;


### PR DESCRIPTION
Had a couple of servers-side crashes where it pointed back to this mod (part of SkyFactory One). Changed round the code to improve performance and we now use these changes. The biggest changes are caching and not creating ItemStacks for functions argument inside loops. Crash reports for prosperity:

Crash Report 1:
```
java.lang.Error: ServerHangWatchdog detected that a single server tick took 60.00 seconds (should be max 0.05)
	at net.minecraftforge.eventbus.EventBus$$Lambda$2542/173247103.invoke(Unknown Source) ~[?:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(ForgeEventFactory.java:597) ~[forge:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(ForgeEventFactory.java:591) ~[forge:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraftforge.common.capabilities.CapabilityProvider.gatherCapabilities(CapabilityProvider.java:48) ~[forge:?] {re:computing_frames,re:mixin,re:classloading}
	at net.minecraft.item.ItemStack.forgeInit(ItemStack.java:998) ~[?:?] {re:mixin,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A}
	at net.minecraft.item.ItemStack.<init>(ItemStack.java:127) ~[?:?] {re:mixin,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A}
	at net.minecraft.item.ItemStack.<init>(ItemStack.java:115) ~[?:?] {re:mixin,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A}
	at net.minecraft.item.ItemStack.<init>(ItemStack.java:107) ~[?:?] {re:mixin,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A}
	at novamachina.exnihilosequentia.common.registries.CrucibleRegistry.lambda$isMeltable$1(CrucibleRegistry.java:38) ~[exnihilosequentia:1.16-20211004011236] {re:classloading}
	at novamachina.exnihilosequentia.common.registries.CrucibleRegistry$$Lambda$15282/390906764.test(Unknown Source) ~[?:?] {}
	at java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90) ~[?:1.8.0_201] {}
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1359) ~[?:1.8.0_201] {}
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126) ~[?:1.8.0_201] {}
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:498) ~[?:1.8.0_201] {}
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485) ~[?:1.8.0_201] {}
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_201] {}
	at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230) ~[?:1.8.0_201] {}
	at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196) ~[?:1.8.0_201] {}
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_201] {}
	at java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:449) ~[?:1.8.0_201] {}
	at novamachina.exnihilosequentia.common.registries.CrucibleRegistry.isMeltable(CrucibleRegistry.java:38) ~[exnihilosequentia:1.16-20211004011236] {re:classloading}
	at novamachina.exnihilosequentia.common.tileentity.crucible.MeltableItemHandler.isItemValid(MeltableItemHandler.java:36) ~[exnihilosequentia:1.16-20211004011236] {re:classloading}
	at net.minecraftforge.items.ItemStackHandler.insertItem(ItemStackHandler.java:84) ~[forge:?] {re:classloading}
	at novamachina.exnihilosequentia.common.tileentity.crucible.MeltableItemHandler.insertItem(MeltableItemHandler.java:25) ~[exnihilosequentia:1.16-20211004011236] {re:classloading}
	at com.lothrazar.cyclic.base.TileEntityBase.moveItems(TileEntityBase.java:312) ~[cyclic:1.16.5-1.5.7] {re:classloading}
	at com.lothrazar.cyclic.base.TileEntityBase.moveItems(TileEntityBase.java:286) ~[cyclic:1.16.5-1.5.7] {re:classloading}
	at com.lothrazar.cyclic.block.cable.item.TileCableItem.normalFlow(TileCableItem.java:89) ~[cyclic:1.16.5-1.5.7] {re:classloading}
	at com.lothrazar.cyclic.block.cable.item.TileCableItem.func_73660_a(TileCableItem.java:69) ~[cyclic:1.16.5-1.5.7] {re:classloading}
	at net.minecraft.world.World.func_217391_K(World.java:491) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerWorld.func_72835_b(ServerWorld.java:371) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:mixins.stevekung's_lib.json:server.level.MixinServerLevel,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:851) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:291) ~[?:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:787) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_240802_v_(MinecraftServer.java:642) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_240783_a_(MinecraftServer.java:232) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer$$Lambda$14313/2117013965.run(Unknown Source) ~[?:?] {}
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_201] {}
```

Crash Report 2:
```
java.lang.Error: ServerHangWatchdog detected that a single server tick took 60.02 seconds (should be max 0.05)
	at com.bloodnbonesgaming.topography.common.config.Preset.fireEventSubscribers(Preset.java:120) ~[topography:1.17.2] {re:classloading}
	at com.bloodnbonesgaming.topography.dedicated.ServerEventHandler.onAllEvents(ServerEventHandler.java:253) ~[topography:1.17.2] {re:classloading}
	at net.minecraftforge.eventbus.ASMEventHandler_694_ServerEventHandler_onAllEvents_Event.invoke(.dynamic) ~[?:?] {}
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus$$Lambda$2534/188747966.invoke(Unknown Source) ~[?:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(ForgeEventFactory.java:597) ~[forge:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(ForgeEventFactory.java:591) ~[forge:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A}
	at net.minecraftforge.common.capabilities.CapabilityProvider.gatherCapabilities(CapabilityProvider.java:48) ~[forge:?] {re:computing_frames,re:mixin,re:classloading}
	at net.minecraft.item.ItemStack.forgeInit(ItemStack.java:998) ~[?:?] {re:mixin,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A}
	at net.minecraft.item.ItemStack.<init>(ItemStack.java:127) ~[?:?] {re:mixin,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A}
	at net.minecraft.item.ItemStack.<init>(ItemStack.java:115) ~[?:?] {re:mixin,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A}
	at net.minecraft.item.ItemStack.<init>(ItemStack.java:107) ~[?:?] {re:mixin,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:forge:itemstack,pl:runtimedistcleaner:A}
	at novamachina.exnihilosequentia.common.registries.HammerRegistry.findRecipe(HammerRegistry.java:35) ~[exnihilosequentia:1.16-20211117-154402] {re:classloading}
	at novamachina.exnihilosequentia.common.registries.HammerRegistry.isHammerable(HammerRegistry.java:29) ~[exnihilosequentia:1.16-20211117-154402] {re:classloading}
	at net.blay09.mods.excompressum.compat.exnihilosequentia.ExNihiloSequentiaAddon.isHammerable(ExNihiloSequentiaAddon.java:154) ~[excompressum:4.0.4] {re:classloading}
	at net.blay09.mods.excompressum.registry.ExNihilo.isHammerable(ExNihilo.java:26) ~[excompressum:4.0.4] {re:classloading}
	at net.blay09.mods.excompressum.tile.AutoHammerTileEntity.isRegistered(AutoHammerTileEntity.java:392) ~[excompressum:4.0.4] {re:classloading}
	at net.blay09.mods.excompressum.tile.AutoHammerTileEntity$2.isItemValid(AutoHammerTileEntity.java:66) ~[excompressum:4.0.4] {re:classloading}
	at net.minecraftforge.items.ItemStackHandler.insertItem(ItemStackHandler.java:84) ~[forge:?] {re:classloading}
	at net.blay09.mods.excompressum.utils.DefaultItemHandler.insertItem(DefaultItemHandler.java:27) ~[excompressum:4.0.4] {re:classloading}
	at net.blay09.mods.excompressum.utils.ItemHandlerAutomation.insertItem(ItemHandlerAutomation.java:34) ~[excompressum:4.0.4] {re:classloading}
	at com.lothrazar.cyclic.base.TileEntityBase.moveItems(TileEntityBase.java:312) ~[cyclic:1.16.5-1.5.7] {re:classloading}
	at com.lothrazar.cyclic.base.TileEntityBase.moveItems(TileEntityBase.java:286) ~[cyclic:1.16.5-1.5.7] {re:classloading}
	at com.lothrazar.cyclic.block.cable.item.TileCableItem.normalFlow(TileCableItem.java:89) ~[cyclic:1.16.5-1.5.7] {re:classloading}
	at com.lothrazar.cyclic.block.cable.item.TileCableItem.func_73660_a(TileCableItem.java:69) ~[cyclic:1.16.5-1.5.7] {re:classloading}
	at net.minecraft.world.World.func_217391_K(World.java:491) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerWorld.func_72835_b(ServerWorld.java:371) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:mixins.stevekung's_lib.json:server.level.MixinServerLevel,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:851) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:291) ~[?:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:787) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_240802_v_(MinecraftServer.java:642) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_240783_a_(MinecraftServer.java:232) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:globaldataandresourcepacks.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer$$Lambda$14301/228840276.run(Unknown Source) ~[?:?] {}
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_201] {}```