### PR TITLE
make crook not drop block if broken

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/common/loot/modifier/UseCrookModifier.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/loot/modifier/UseCrookModifier.java
@@ -82,9 +82,12 @@ public class UseCrookModifier extends LootModifier {
                 newLoot.add(new ItemStack(Items.STRING, random
                         .nextInt(Config.getMaxBonusStringCount()) + Config.getMinStringCount()));
                 if (random.nextDouble() <= 0.8) {
-                    newLoot
-                            .add(new ItemStack(ExNihiloItems.SILKWORM.get()));
+                    newLoot.add(new ItemStack(ExNihiloItems.SILKWORM.get()));
                 }
+            }
+            //TODO added this to make crook not drop additional block
+            if (newLoot.isEmpty()) {
+                return new ArrayList<>();
             }
         }
         if (!newLoot.isEmpty()) {


### PR DESCRIPTION
Fixing a bug when adding custom recipes for crook that the block broken gets sometimes dropped instead of air. this PR adds a check, if newLoot is empty. if it is, it'll return an empty list instead of the block broken.