### PR TITLE
Add tag for ore pieces

### DIFF
--- a/src/datagen/generated/exnihilomekanism/data/exnihilosequentia/tags/items/pieces.json
+++ b/src/datagen/generated/exnihilomekanism/data/exnihilosequentia/tags/items/pieces.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "exnihilomekanism:osmium_pieces"
+  ]
+}

--- a/src/datagen/generated/exnihilosequentia/data/exnihilosequentia/tags/items/pieces.json
+++ b/src/datagen/generated/exnihilosequentia/data/exnihilosequentia/tags/items/pieces.json
@@ -1,0 +1,16 @@
+{
+  "replace": false,
+  "values": [
+    "exnihilosequentia:iron_pieces",
+    "exnihilosequentia:gold_pieces",
+    "exnihilosequentia:copper_pieces",
+    "exnihilosequentia:lead_pieces",
+    "exnihilosequentia:nickel_pieces",
+    "exnihilosequentia:silver_pieces",
+    "exnihilosequentia:tin_pieces",
+    "exnihilosequentia:aluminum_pieces",
+    "exnihilosequentia:platinum_pieces",
+    "exnihilosequentia:uranium_pieces",
+    "exnihilosequentia:zinc_pieces"
+  ]
+}

--- a/src/datagen/generated/exnihilotinkers/data/exnihilosequentia/tags/items/pieces.json
+++ b/src/datagen/generated/exnihilotinkers/data/exnihilosequentia/tags/items/pieces.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "exnihilotinkers:cobalt_pieces"
+  ]
+}

--- a/src/datagen/main/java/novamachina/exnihilosequentia/api/datagen/AbstractItemTagGenerator.java
+++ b/src/datagen/main/java/novamachina/exnihilosequentia/api/datagen/AbstractItemTagGenerator.java
@@ -38,6 +38,12 @@ public abstract class AbstractItemTagGenerator extends ItemTagsProvider {
       tag(Tags.Items.INGOTS).addTag(tags.getIngotTag());
 
     }
+
+    @Nullable final Item piece = ore.getPieceItem();
+    if (piece != null) {
+      tag(ExNihiloTags.PIECE).add(piece);
+    }
+
     @Nullable final Item chunk = ore.getRawOreItem();
     if (chunk == null) {
       return;

--- a/src/main/java/novamachina/exnihilosequentia/api/tag/ExNihiloTags.java
+++ b/src/main/java/novamachina/exnihilosequentia/api/tag/ExNihiloTags.java
@@ -25,6 +25,8 @@ public class ExNihiloTags {
   @Nonnull public static final TagKey<Item> BARREL = ItemTags.create(modLoc("barrels"));
   @Nonnull public static final TagKey<Item> SIEVE = ItemTags.create(modLoc("sieves"));
 
+  @Nonnull public static final TagKey<Item> PIECE = ItemTags.create(modLoc("pieces"));
+
   @Nonnull
   public static final TagKey<Block> MINEABLE_WITH_CROOK =
       BlockTags.create(modLoc("mineable/crook"));


### PR DESCRIPTION
This adds the `exnihilosequentia:pieces` tag for all ore pieces. Having a tag allows mods that do tag based filtering, like Pipez, to easily extract all pieces without manually adding each one.