### PR TITLE
[1.18] support filling barrels with fluid of modded items

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/common/blockentity/barrel/mode/FluidsBarrelMode.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/blockentity/barrel/mode/FluidsBarrelMode.java
@@ -198,7 +198,7 @@ public class FluidsBarrelMode extends AbstractBarrelMode {
 
   @Override
   protected boolean isTriggerItem(@Nonnull final ItemStack stack) {
-    return stack.getItem() instanceof BucketItem ||
+    return FluidUtil.getFluidContained(stack).map(FluidStack::getAmount).orElse(0) >= FluidAttributes.BUCKET_VOLUME ||
         ItemStack.isSame(stack, PotionUtils.setPotion(new ItemStack(Items.POTION), Potions.WATER));
   }
 


### PR DESCRIPTION
Fixes #323

This PR fixes the problem that modded fluid container items cannot fill ex nihilo barrels. You can test it by using one of my mods: [Wooden Bucket](https://www.curseforge.com/minecraft/mc-mods/wooden-bucket) or [Ceramic Bucket](https://www.curseforge.com/minecraft/mc-mods/ceramic-bucket) (they need [BucketLib](https://www.curseforge.com/minecraft/mc-mods/bucketlib)).

This PR is for version 1.18. I hope it could be released there. It can also be used to fix this issue in 1.19 if it is also there. :)

related issue: https://github.com/cech12/BucketLib/issues/15