### PR TITLE
Fix crafttweaker only uppercase sensitive mesh

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/sieve/SieveRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/sieve/SieveRecipe.java
@@ -51,7 +51,7 @@ public class SieveRecipe extends SerializableRecipe {
   }
 
   public void addRoll(@Nonnull final String meshString, final float chance) {
-    @Nonnull final MeshType mesh = MeshType.valueOf(meshString);
+    @Nonnull final MeshType mesh = MeshType.valueOf(meshString.toUpperCase());
     addRoll(mesh, chance);
   }
 


### PR DESCRIPTION
This PR fixes #329 by just setting all incoming strings on addRoll(String, Int) to UPPERCASE

Tested with this script:

import mods.exnihilosequentia.ZenSieveRecipe;

<recipetype:exnihilosequentia:sieve>
    .create("example")
    .setInput(<item:minecraft:cobblestone>)
    .addDrop(<item:minecraft:netherite_ingot>)
    .addRoll("diamond", 0.01)
    .addRoll("NETHERITE", 0.1)
    .addRoll("sTrInG", 1.0);

all 3 recipes are shown at netherite level