### PR TITLE
fix crt remove by input doesn't work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'org.parchmentmc.librarian.forgegradle'
 
 sonarqube {
     properties {
-        property "sonar.projectKey", "NovaMachina-Mods_ExNihiloSequentia_AYGoA_nsnvMbtB54W0q1"
+        property "sonar.projectKey", "NovaMachina-Mods_ExNihiloSequentia_AYJwMe16kf6704OXoPeu"
     }
 }
 

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/SingleItemInputRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/SingleItemInputRecipe.java
@@ -1,0 +1,41 @@
+package novamachina.exnihilosequentia.common.crafting;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class SingleItemInputRecipe extends SerializableRecipe {
+    @Nonnull
+    protected Ingredient input;
+
+    protected SingleItemInputRecipe(@Nullable ItemStack outputDummy, @Nonnull Ingredient input, @Nonnull RecipeType<?> type, @Nonnull ResourceLocation id) {
+        super(outputDummy, type, id);
+        this.input = input;
+    }
+
+    public final void setInput(@Nonnull Ingredient input) {
+        this.input = input;
+    }
+
+    @Nonnull
+    public final Ingredient getInput() {
+        return input;
+    }
+
+    @Nonnull
+    public final List<ItemStack> getInputs() {
+        return Arrays.asList(input.getItems());
+    }
+
+    @Override
+    public NonNullList<Ingredient> getIngredients() {
+        return NonNullList.of(Ingredient.EMPTY, input);
+    }
+}

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/compost/CompostRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/compost/CompostRecipe.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -58,6 +60,11 @@ public class CompostRecipe extends SerializableRecipe {
   @Nonnull
   public List<ItemStack> getInputs() {
     return Arrays.asList(input.getItems());
+  }
+
+  @Override
+  public NonNullList<Ingredient> getIngredients() {
+    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/compost/CompostRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/compost/CompostRecipe.java
@@ -1,33 +1,26 @@
 package novamachina.exnihilosequentia.common.crafting.compost;
 
-import java.util.Arrays;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.registries.RegistryObject;
 import novamachina.exnihilosequentia.common.crafting.ExNihiloRecipeSerializer;
-import novamachina.exnihilosequentia.common.crafting.SerializableRecipe;
-import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
+import novamachina.exnihilosequentia.common.crafting.SingleItemInputRecipe;
 
-public class CompostRecipe extends SerializableRecipe {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class CompostRecipe extends SingleItemInputRecipe {
 
   public static RecipeType<CompostRecipe> RECIPE_TYPE;
   @Nullable
   private static RegistryObject<ExNihiloRecipeSerializer<CompostRecipe>> serializer;
   private int amount;
-  @Nonnull
-  private Ingredient input;
 
   public CompostRecipe(@Nonnull final ResourceLocation id, @Nonnull final Ingredient input,
       final int amount) {
-    super(null, RECIPE_TYPE, id);
-    this.input = input;
+    super(null, input, RECIPE_TYPE, id);
     this.amount = amount;
   }
 
@@ -46,25 +39,6 @@ public class CompostRecipe extends SerializableRecipe {
 
   public void setAmount(final int amount) {
     this.amount = amount;
-  }
-
-  @Nonnull
-  public Ingredient getInput() {
-    return input;
-  }
-
-  public void setInput(@Nonnull final Ingredient input) {
-    this.input = input;
-  }
-
-  @Nonnull
-  public List<ItemStack> getInputs() {
-    return Arrays.asList(input.getItems());
-  }
-
-  @Override
-  public NonNullList<Ingredient> getIngredients() {
-    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/crook/CrookRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/crook/CrookRecipe.java
@@ -1,12 +1,5 @@
 package novamachina.exnihilosequentia.common.crafting.crook;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -14,23 +7,24 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.registries.RegistryObject;
 import novamachina.exnihilosequentia.common.crafting.ExNihiloRecipeSerializer;
 import novamachina.exnihilosequentia.common.crafting.ItemStackWithChance;
-import novamachina.exnihilosequentia.common.crafting.SerializableRecipe;
-import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
+import novamachina.exnihilosequentia.common.crafting.SingleItemInputRecipe;
 
-public class CrookRecipe extends SerializableRecipe {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CrookRecipe extends SingleItemInputRecipe {
 
   public static RecipeType<CrookRecipe> RECIPE_TYPE;
   @Nullable
   private static RegistryObject<ExNihiloRecipeSerializer<CrookRecipe>> serializer;
   @Nonnull
   private final List<ItemStackWithChance> output;
-  @Nonnull
-  private Ingredient input;
 
   public CrookRecipe(@Nonnull final ResourceLocation id, @Nonnull final Ingredient input,
       @Nonnull final List<ItemStackWithChance> output) {
-    super(output.isEmpty() ? ItemStack.EMPTY : output.get(0).getStack(), RECIPE_TYPE, id);
-    this.input = input;
+    super(output.isEmpty() ? ItemStack.EMPTY : output.get(0).getStack(), input, RECIPE_TYPE, id);
     this.output = output;
   }
 
@@ -49,20 +43,6 @@ public class CrookRecipe extends SerializableRecipe {
   }
 
   @Nonnull
-  public Ingredient getInput() {
-    return input;
-  }
-
-  public void setInput(@Nonnull final Ingredient input) {
-    this.input = input;
-  }
-
-  @Nonnull
-  public List<ItemStack> getInputs() {
-    return Arrays.asList(input.getItems());
-  }
-
-  @Nonnull
   public List<ItemStackWithChance> getOutput() {
     return output;
   }
@@ -78,11 +58,6 @@ public class CrookRecipe extends SerializableRecipe {
   @Nonnull
   public ItemStack getResultItem() {
     return output.isEmpty() ? ItemStack.EMPTY : output.get(0).getStack().copy();
-  }
-
-  @Override
-  public NonNullList<Ingredient> getIngredients() {
-    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/crook/CrookRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/crook/CrookRecipe.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -76,6 +78,11 @@ public class CrookRecipe extends SerializableRecipe {
   @Nonnull
   public ItemStack getResultItem() {
     return output.isEmpty() ? ItemStack.EMPTY : output.get(0).getStack().copy();
+  }
+
+  @Override
+  public NonNullList<Ingredient> getIngredients() {
+    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/crucible/CrucibleRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/crucible/CrucibleRecipe.java
@@ -1,11 +1,5 @@
 package novamachina.exnihilosequentia.common.crafting.crucible;
 
-import java.util.Arrays;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -14,10 +8,12 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.RegistryObject;
 import novamachina.exnihilosequentia.common.blockentity.crucible.CrucibleTypeEnum;
 import novamachina.exnihilosequentia.common.crafting.ExNihiloRecipeSerializer;
-import novamachina.exnihilosequentia.common.crafting.SerializableRecipe;
-import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
+import novamachina.exnihilosequentia.common.crafting.SingleItemInputRecipe;
 
-public class CrucibleRecipe extends SerializableRecipe {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class CrucibleRecipe extends SingleItemInputRecipe {
 
   public static RecipeType<CrucibleRecipe> RECIPE_TYPE;
   @Nullable
@@ -26,15 +22,12 @@ public class CrucibleRecipe extends SerializableRecipe {
   @Nullable
   private CrucibleTypeEnum crucibleType;
   @Nonnull
-  private Ingredient input;
-  @Nonnull
   private FluidStack resultFluid;
 
   public CrucibleRecipe(@Nonnull final ResourceLocation id, @Nonnull final Ingredient input,
       final int amount,
       @Nonnull final FluidStack fluid, @Nonnull final CrucibleTypeEnum crucibleType) {
-    super(null, RECIPE_TYPE, id);
-    this.input = input;
+    super(null, input, RECIPE_TYPE, id);
     this.amount = amount;
     this.resultFluid = fluid;
     this.crucibleType = crucibleType;
@@ -65,25 +58,6 @@ public class CrucibleRecipe extends SerializableRecipe {
 
   public void setCrucibleType(@Nonnull final String crucibleType) {
     this.crucibleType = CrucibleTypeEnum.getTypeByName(crucibleType);
-  }
-
-  @Nonnull
-  public Ingredient getInput() {
-    return input;
-  }
-
-  public void setInput(@Nonnull final Ingredient input) {
-    this.input = input;
-  }
-
-  @Nonnull
-  public List<ItemStack> getInputs() {
-    return Arrays.asList(input.getItems());
-  }
-
-  @Override
-  public NonNullList<Ingredient> getIngredients() {
-    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/crucible/CrucibleRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/crucible/CrucibleRecipe.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -77,6 +79,11 @@ public class CrucibleRecipe extends SerializableRecipe {
   @Nonnull
   public List<ItemStack> getInputs() {
     return Arrays.asList(input.getItems());
+  }
+
+  @Override
+  public NonNullList<Ingredient> getIngredients() {
+    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/fluiditem/FluidItemRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/fluiditem/FluidItemRecipe.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -63,6 +65,11 @@ public class FluidItemRecipe extends SerializableRecipe {
   @Nonnull
   public List<ItemStack> getInputs() {
     return Arrays.asList(input.getItems());
+  }
+
+  @Override
+  public NonNullList<Ingredient> getIngredients() {
+    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/fluiditem/FluidItemRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/fluiditem/FluidItemRecipe.java
@@ -1,11 +1,5 @@
 package novamachina.exnihilosequentia.common.crafting.fluiditem;
 
-import java.util.Arrays;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -15,10 +9,12 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.RegistryObject;
 import novamachina.exnihilosequentia.common.crafting.ExNihiloRecipeSerializer;
-import novamachina.exnihilosequentia.common.crafting.SerializableRecipe;
-import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
+import novamachina.exnihilosequentia.common.crafting.SingleItemInputRecipe;
 
-public class FluidItemRecipe extends SerializableRecipe {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class FluidItemRecipe extends SingleItemInputRecipe {
 
   public static RecipeType<FluidItemRecipe> RECIPE_TYPE;
   @Nullable
@@ -26,15 +22,12 @@ public class FluidItemRecipe extends SerializableRecipe {
   @Nonnull
   private FluidStack fluid;
   @Nonnull
-  private Ingredient input;
-  @Nonnull
   private ItemStack output;
 
   public FluidItemRecipe(@Nonnull final ResourceLocation id, @Nonnull final FluidStack fluid,
       @Nonnull final Ingredient input, @Nonnull final ItemStack output) {
-    super(output, RECIPE_TYPE, id);
+    super(output, input, RECIPE_TYPE, id);
     this.fluid = fluid;
-    this.input = input;
     this.output = output;
   }
 
@@ -51,25 +44,6 @@ public class FluidItemRecipe extends SerializableRecipe {
   @Nonnull
   public FluidStack getFluidInBarrel() {
     return fluid;
-  }
-
-  @Nonnull
-  public Ingredient getInput() {
-    return input;
-  }
-
-  public void setInput(@Nonnull final Ingredient input) {
-    this.input = input;
-  }
-
-  @Nonnull
-  public List<ItemStack> getInputs() {
-    return Arrays.asList(input.getItems());
-  }
-
-  @Override
-  public NonNullList<Ingredient> getIngredients() {
-    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/fluidtransform/FluidTransformRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/fluidtransform/FluidTransformRecipe.java
@@ -2,6 +2,8 @@ package novamachina.exnihilosequentia.common.crafting.fluidtransform;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -10,7 +12,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.RegistryObject;
 import novamachina.exnihilosequentia.common.crafting.ExNihiloRecipeSerializer;
 import novamachina.exnihilosequentia.common.crafting.SerializableRecipe;
-import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
 
 public class FluidTransformRecipe extends SerializableRecipe {
 
@@ -65,6 +66,11 @@ public class FluidTransformRecipe extends SerializableRecipe {
   @Nonnull
   public ItemStack getResultItem() {
     return ItemStack.EMPTY;
+  }
+
+  @Override
+  public NonNullList<Ingredient> getIngredients() {
+    return NonNullList.of(Ingredient.EMPTY, catalyst);
   }
 
   @Nonnull

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/fluidtransform/FluidTransformRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/fluidtransform/FluidTransformRecipe.java
@@ -1,9 +1,5 @@
 package novamachina.exnihilosequentia.common.crafting.fluidtransform;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -11,9 +7,12 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.RegistryObject;
 import novamachina.exnihilosequentia.common.crafting.ExNihiloRecipeSerializer;
-import novamachina.exnihilosequentia.common.crafting.SerializableRecipe;
+import novamachina.exnihilosequentia.common.crafting.SingleItemInputRecipe;
 
-public class FluidTransformRecipe extends SerializableRecipe {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class FluidTransformRecipe extends SingleItemInputRecipe {
 
   public static RecipeType<FluidTransformRecipe> RECIPE_TYPE;
   @Nullable
@@ -28,7 +27,7 @@ public class FluidTransformRecipe extends SerializableRecipe {
   public FluidTransformRecipe(@Nonnull final ResourceLocation id,
       @Nonnull final FluidStack fluidInTank,
       @Nonnull final Ingredient catalyst, @Nonnull final FluidStack result) {
-    super(null, RECIPE_TYPE, id);
+    super(null, catalyst, RECIPE_TYPE, id);
     this.fluidInTank = fluidInTank;
     this.catalyst = catalyst;
     this.result = result;
@@ -66,11 +65,6 @@ public class FluidTransformRecipe extends SerializableRecipe {
   @Nonnull
   public ItemStack getResultItem() {
     return ItemStack.EMPTY;
-  }
-
-  @Override
-  public NonNullList<Ingredient> getIngredients() {
-    return NonNullList.of(Ingredient.EMPTY, catalyst);
   }
 
   @Nonnull

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/hammer/HammerRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/hammer/HammerRecipe.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -70,6 +72,11 @@ public class HammerRecipe extends SerializableRecipe {
     List<ItemStack> returnList = new ArrayList<>();
     output.forEach(stack -> returnList.add(stack.getStack()));
     return returnList;
+  }
+
+  @Override
+  public NonNullList<Ingredient> getIngredients() {
+    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/hammer/HammerRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/hammer/HammerRecipe.java
@@ -1,11 +1,5 @@
 package novamachina.exnihilosequentia.common.crafting.hammer;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -13,9 +7,14 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.registries.RegistryObject;
 import novamachina.exnihilosequentia.common.crafting.ExNihiloRecipeSerializer;
 import novamachina.exnihilosequentia.common.crafting.ItemStackWithChance;
-import novamachina.exnihilosequentia.common.crafting.SerializableRecipe;
+import novamachina.exnihilosequentia.common.crafting.SingleItemInputRecipe;
 
-public class HammerRecipe extends SerializableRecipe {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HammerRecipe extends SingleItemInputRecipe {
 
   @Nonnull
   public static final HammerRecipe EMPTY = new HammerRecipe(new ResourceLocation("empty"),
@@ -25,13 +24,10 @@ public class HammerRecipe extends SerializableRecipe {
   private static RegistryObject<ExNihiloRecipeSerializer<HammerRecipe>> serializer;
   @Nonnull
   private final List<ItemStackWithChance> output;
-  @Nonnull
-  private Ingredient input;
 
   public HammerRecipe(@Nonnull final ResourceLocation id, @Nonnull final Ingredient input,
       @Nonnull final List<ItemStackWithChance> output) {
-    super(ItemStack.EMPTY, RECIPE_TYPE, id);
-    this.input = input;
+    super(ItemStack.EMPTY, input, RECIPE_TYPE, id);
     this.output = output;
   }
 
@@ -54,15 +50,6 @@ public class HammerRecipe extends SerializableRecipe {
   }
 
   @Nonnull
-  public Ingredient getInput() {
-    return input;
-  }
-
-  public void setInput(@Nonnull final Ingredient input) {
-    this.input = input;
-  }
-
-  @Nonnull
   public List<ItemStackWithChance> getOutput() {
     return output;
   }
@@ -72,11 +59,6 @@ public class HammerRecipe extends SerializableRecipe {
     List<ItemStack> returnList = new ArrayList<>();
     output.forEach(stack -> returnList.add(stack.getStack()));
     return returnList;
-  }
-
-  @Override
-  public NonNullList<Ingredient> getIngredients() {
-    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Override

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/sieve/SieveRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/sieve/SieveRecipe.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -103,6 +105,11 @@ public class SieveRecipe extends SerializableRecipe {
   @Nonnull
   public ItemStack getResultItem() {
     return drop.copy();
+  }
+
+  @Override
+  public NonNullList<Ingredient> getIngredients() {
+    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Nonnull

--- a/src/main/java/novamachina/exnihilosequentia/common/crafting/sieve/SieveRecipe.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/crafting/sieve/SieveRecipe.java
@@ -1,22 +1,20 @@
 package novamachina.exnihilosequentia.common.crafting.sieve;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import net.minecraft.core.NonNullList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.registries.RegistryObject;
 import novamachina.exnihilosequentia.common.crafting.ExNihiloRecipeSerializer;
-import novamachina.exnihilosequentia.common.crafting.SerializableRecipe;
+import novamachina.exnihilosequentia.common.crafting.SingleItemInputRecipe;
 import novamachina.exnihilosequentia.common.item.mesh.MeshType;
-import novamachina.exnihilosequentia.common.utility.ExNihiloConstants;
 
-public class SieveRecipe extends SerializableRecipe {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SieveRecipe extends SingleItemInputRecipe {
 
   public static RecipeType<SieveRecipe> RECIPE_TYPE;
   @Nullable
@@ -27,16 +25,13 @@ public class SieveRecipe extends SerializableRecipe {
   private final List<MeshWithChance> rolls;
   @Nonnull
   private ItemStack drop;
-  @Nonnull
-  private Ingredient input;
   private boolean isWaterlogged;
 
   public SieveRecipe(@Nonnull final ResourceLocation id, @Nonnull final Ingredient input,
       @Nonnull final ItemStack drop, @Nonnull final List<MeshWithChance> rolls,
       boolean isWaterlogged) {
-    super(drop, RECIPE_TYPE, id);
+    super(drop, input, RECIPE_TYPE, id);
     this.recipeId = id;
-    this.input = input;
     this.drop = drop;
     this.rolls = rolls;
     this.isWaterlogged = isWaterlogged;
@@ -88,15 +83,6 @@ public class SieveRecipe extends SerializableRecipe {
   }
 
   @Nonnull
-  public Ingredient getInput() {
-    return input;
-  }
-
-  public void setInput(@Nonnull final Ingredient input) {
-    this.input = input;
-  }
-
-  @Nonnull
   public ResourceLocation getRecipeId() {
     return recipeId;
   }
@@ -105,11 +91,6 @@ public class SieveRecipe extends SerializableRecipe {
   @Nonnull
   public ItemStack getResultItem() {
     return drop.copy();
-  }
-
-  @Override
-  public NonNullList<Ingredient> getIngredients() {
-    return NonNullList.of(Ingredient.EMPTY, input);
   }
 
   @Nonnull


### PR DESCRIPTION
Simply overriding `IRecipe#getIngredients` will solve the issue (#312). This PR only fixes the issue in 1.18 version. For 1.16 and the future version (1.19), I hope the author of this repo fixes it. (just don't want to make 3 PRs with the same content)