### PR TITLE
Fix uncontrollable Crashes

### DIFF
--- a/src/main/java/novamachina/exnihilosequentia/common/registries/HammerRegistry.java
+++ b/src/main/java/novamachina/exnihilosequentia/common/registries/HammerRegistry.java
@@ -1,9 +1,9 @@
 package novamachina.exnihilosequentia.common.registries;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
@@ -21,7 +21,7 @@ public class HammerRegistry {
   private static final List<HammerRecipe> recipeList = new ArrayList<>();
 
   @Nonnull
-  private final Map<Block, HammerRecipe> recipeByBlockCache = new HashMap<>();
+  private final Map<Block, HammerRecipe> recipeByBlockCache = new ConcurrentHashMap<>();
 
   @Nonnull
   public List<ItemStackWithChance> getResult(@Nonnull final Block input) {


### PR DESCRIPTION
This PR fixes #408 by using ConcurrentHashMaps instead of HashMaps to prevent the ConcurrentModificationException which some players experience.